### PR TITLE
Add basic RTL support for chat bubbles

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -15,7 +15,8 @@ export async function renderChat(app: App, nodes: ChatNode[], el: HTMLElement, c
           "chat-view-message",
           `chat-view-message-${node.side}`,
           ...(isContinued ? ["chat-view-message-continued"] : []),
-        ]
+        ],
+        attr: {dir: "auto"}
       });
       if (node.header.length > 0 && !isContinued) {
         if (!headerColors.has(node.header)) headerColors.set(node.header, colors[headerColors.size % colors.length]!);
@@ -31,7 +32,7 @@ export async function renderChat(app: App, nodes: ChatNode[], el: HTMLElement, c
         messageDiv.createDiv({cls: ["chat-view-subtext"], text: node.subtext});
       }
     } else if (node.kind === "comment") {
-      chatViewDiv.createDiv({cls: ["chat-view-comment"], text: node.body});
+      chatViewDiv.createDiv({cls: ["chat-view-comment"], text: node.body, attr: {dir: "auto"}});
     } else if (node.kind === "delimiter") {
       const delimiter = chatViewDiv.createDiv({cls: ["chat-view-delimiter"]});
       for (let i = 0; i < 3; i++) {


### PR DESCRIPTION
# Add basic RTL support for chat bubbles

### Description:

Fixes incorrect text direction for RTL languages (e.g. Hebrew, Arabic) inside chat messages.

### Problem:

- Names and timestamps were always aligned left, even for RTL text.
- Punctuation appeared on the wrong side of RTL sentences.
- Markdown headings (`#`) inside a message body rendered with the wrong direction/alignment.

<img width="737" height="471" alt="Before" src="https://github.com/user-attachments/assets/96c50c83-fa5d-4790-9d77-65c51f0f5bed" />

### Fix:

Added `dir="auto"` to each chat bubble and comment element. This detect the text direction from the message's own content and render it correctly, so Hebrew / Arabic text, punctuation, and Markdown headings inside the bubble now flow right-to-left when the content is RTL. This only affects text direction inside the bubble. It does not change which side the bubble appears on.

<img width="741" height="473" alt="After" src="https://github.com/user-attachments/assets/a3921c12-3ef2-480a-9967-eeff5b3dcc3f" />


### Scope:

- One file changed: `src/renderer.ts`.
- Bubble left/right/center positioning (driven by the `>` / `^` metadata) is unchanged.
- Applies to all chat formats (`chat`, `chat-old`, `chat-webvtt`, `chat-zendesk`, `chat-intercom`) since they all share this renderer...